### PR TITLE
Correct the fetch author name issue

### DIFF
--- a/R/process_pubmed.R
+++ b/R/process_pubmed.R
@@ -148,7 +148,7 @@ formatData<-function(ids = NULL, ncbi_key = NA, forceGet=TRUE){
     
     #convert author list from list object to string obeject with author names seperated by ;
     authors<-sapply(pubResults@Author,function(x){
-      apply(x,1,function(y){sprintf("%s, %s",y[1],y[2])}) %>% paste0(.,collapse=";")
+      apply(x,1,function(y){sprintf("%s, %s",y[2],y[3])}) %>% paste0(.,collapse=";")
     })
     
     #also convert mesh Terms from a list


### PR DESCRIPTION
The Author name string was NA, Last name. I figure out that the RISmed library was saving the @Author field in the Medline object in the following format: $`34229008`
                   CollectiveName            LastName   ForeName              Initials             order
Author              NA                           Khajavi         Mohaddeseh        M                        1 
Author1             NA                           Hashemi     Maryam                 M                        2
Author2             NA                           Kalalinia        Fatemeh               F                         3


Hence the apply function on line 149 was fetching the 1st and second columns on that field (Collective name and Last Name).

I changed the indexes to correct the behavior.